### PR TITLE
feat: bundle the framework without starting luna to allow custom handers

### DIFF
--- a/packages/cli/build/configs/rollup.config.start.js
+++ b/packages/cli/build/configs/rollup.config.start.js
@@ -10,13 +10,14 @@ export default async () => {
 
 	const production = process.env.NODE_ENV === 'production';
 
-	const bundle = {
-		input: '@webtides/luna-js/start.js',
-		output: {
+	const entries = [ 'start', 'framework' ];
+	return entries.map((entry) => ({
+		input: `@webtides/luna-js/${entry}.js`,
+			output: {
 			dir: settings._generated.baseDirectory,
-			entryFileNames: 'start.js',
-			sourcemap: production ? false : 'inline',
-			format: 'cjs',
+				entryFileNames: `${entry}.js`,
+				sourcemap: production ? false : 'inline',
+				format: 'cjs',
 		},
 		plugins: [
 			nodeResolve({
@@ -28,7 +29,5 @@ export default async () => {
 			}),
 			json(),
 		],
-	};
-
-	return [bundle];
+	}));
 };

--- a/packages/cli/src/tasks/build.js
+++ b/packages/cli/src/tasks/build.js
@@ -1,5 +1,5 @@
 import * as rollup from 'rollup';
-import loadConfigFile from 'rollup/dist/loadConfigFile';
+import loadConfigFile from 'rollup/dist/loadConfigFile.js';
 
 const startRollupWatch = async (configFile, callback = () => {}, fileRemovedCallback = () => {}) => {
 	try {

--- a/packages/cli/src/tasks/prepare.js
+++ b/packages/cli/src/tasks/prepare.js
@@ -1,11 +1,14 @@
 import fs from 'fs';
-import path from 'path';
+import genericPath from 'path';
 
 import deepmerge from 'deepmerge';
 import inquirer from 'inquirer';
 
 import { getConfig, setConfig } from '../config';
 import defaultSettings from './prepare/luna.config.base';
+
+// Use the posix module to generate posix style directory separators on windows machines.
+const path = genericPath.posix;
 
 const getPathToConfigFile = (currentWorkingDirectory = process.cwd()) => {
 	return path.join(currentWorkingDirectory, 'luna.config.js');

--- a/packages/luna/framework.js
+++ b/packages/luna/framework.js
@@ -1,0 +1,3 @@
+export { startLuna, prepareLuna, stopLuna } from './src/framework';
+export { callHook } from './src/framework/hooks';
+export { HOOKS } from './src/framework/hooks/definitions';

--- a/packages/luna/src/framework/index.js
+++ b/packages/luna/src/framework/index.js
@@ -13,7 +13,7 @@ import LayoutsLoader from "./loaders/layouts-loader";
  * This methods should be called before anything else.
  * Performs checks for required files and loads the settings.
  *
- * @returns {Promise<boolean>}
+ * @returns {Promise<boolean|Server>}
  */
 const prepareLuna = async ({ config } = {}) => {
     // First we load all settings.
@@ -29,33 +29,34 @@ const prepareLuna = async ({ config } = {}) => {
         global.luna = luna;
     }
 
-    return true;
+	await global.luna.initialize();
+
+	await callHook(HOOKS.HOOKS_LOADED);
+
+	const componentLoader = global.luna.get(ComponentLoader);
+	await componentLoader.registerAvailableComponents();
+
+	await callHook(HOOKS.COMPONENTS_LOADED, {
+		components: componentLoader.getAvailableComponents()
+	});
+
+	const layoutsLoader = global.luna.get(LayoutsLoader);
+	await layoutsLoader.registerAvailableLayouts();
+
+	return global.luna.get(Server);
 };
 
 const startLuna = async ({ config } = {}) => {
     global.luna = undefined;
 
-    if (!(await prepareLuna({ config }))) {
+    const server = await prepareLuna({ config });
+    if (!server) {
         console.log("Could not start luna-js. Have you created your luna.config.js?");
         return;
     }
 
-    await global.luna.initialize();
-
-    await callHook(HOOKS.HOOKS_LOADED);
-
-    const componentLoader = luna.get(ComponentLoader);
-    await componentLoader.registerAvailableComponents();
-
-    await callHook(HOOKS.COMPONENTS_LOADED, {
-        components: componentLoader.getAvailableComponents()
-    });
-
-    const layoutsLoader = luna.get(LayoutsLoader);
-    await layoutsLoader.registerAvailableLayouts();
-
-    const server = luna.get(Server);
     await server.start();
+    return server;
 };
 
 const stopLuna = async () => {

--- a/packages/luna/src/framework/loaders/component-loader.js
+++ b/packages/luna/src/framework/loaders/component-loader.js
@@ -68,7 +68,7 @@ export default class ComponentLoader {
 
         for (const componentModule of manifest.components) {
             const {file, relativePath, settings, children} = componentModule;
-            const absolutePath = path.join(basePath, file);
+            const absolutePath = path.posix.join(basePath, file);
 
             const component = await this.loadSingleComponent({
                 absolutePath, file, relativePath, settings, children


### PR DESCRIPTION
With this we open up the possibility for other developers to write custom handlers for their luna application. Testing wise i have updated the luna docs (https://docs.lunajs.dev/) to use this version.

The script that is needed on the custom project can look like this.

```js
const serverless = require('serverless-http');
const { prepareLuna, callHook, HOOKS } = require('./.build/generated/framework.js');

let server = undefined;

const initialize = async () => {
    server = await prepareLuna();
    await server.prepare();

    callHook(HOOKS.SERVER_STARTED, { app: server.app });
};

const handler = async (event, context) => {
    if (!server) {
        await initialize();
    }

    return serverless(server.app, {
        binary: ['image/*', 'application/*'],
    })(event, context);
};

module.exports.handler = handler;
```
closes #104 